### PR TITLE
Change badge link on homepage

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -166,7 +166,7 @@
             tom.mcnulty.in
         </a>
 
-        <a href="https://github.com/YanFett/Wintergatan_data_analysis" id="githubBadge">
+        <a href="https://github.com/Wintergatan/Tightinator" id="githubBadge">
             <img src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" alt="GitHub Logo" style="width: 20px; vertical-align: middle;">
             View source on GitHub
         </a>


### PR DESCRIPTION
Insignificant due to github redirects, but updates the hover text.