### PR TITLE
Fix MIME type detection on Linux

### DIFF
--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -305,6 +305,7 @@
         fileInput.addEventListener('change', (e) => {
             const file = e.target.files[0];
 
+            if (['audio/wav', 'audio/x-wav'].includes(file.type)) { // Check if the MIME type of the uploaded file indicates .wav
                 const formData = new FormData();
                 formData.append('file', file);
 

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -189,7 +189,7 @@
         fileInput.addEventListener('change', (e) => {
             const file = e.target.files[0];
 
-            if (['audio/wav', 'audio/x-wav'].includes(file.type)) {
+            if (['audio/wav', 'audio/x-wav'].includes(file.type)) { // Check if the MIME type of the uploaded file indicates .wav
                 const formData = new FormData();
                 formData.append('file', file);
 
@@ -256,7 +256,7 @@
 
             const file = e.dataTransfer.files[0];
 
-            if (file.type === 'audio/wav') {
+            if (['audio/wav', 'audio/x-wav'].includes(file.type)) { // Check if the MIME type of the uploaded file indicates .wav
                 const formData = new FormData();
                 formData.append('file', file);
 

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -189,7 +189,7 @@
         fileInput.addEventListener('change', (e) => {
             const file = e.target.files[0];
 
-            if (file.type === 'audio/wav') {
+            if (['audio/wav', 'audio/x-wav'].includes(file.type)) {
                 const formData = new FormData();
                 formData.append('file', file);
 
@@ -232,6 +232,7 @@
                 xhr.send(formData);
             } else {
                 console.log('Invalid file type. Please select a .wav file.');
+                alert('Invalid file type. Please select a .wav file.'); // Tell the user so they don't think the app is broken
             }
         });
 
@@ -298,13 +299,13 @@
                 xhr.send(formData);
             } else {
                 console.log('Invalid file type. Please select a .wav file.');
+                alert('Invalid file type. Please select a .wav file.'); // Tell the user so they don't think the app is broken
             }
         });
 
         fileInput.addEventListener('change', (e) => {
             const file = e.target.files[0];
 
-            if (file.type === 'audio/wav') {
                 const formData = new FormData();
                 formData.append('file', file);
 


### PR DESCRIPTION
On Linux it seems like JavaScript's `type` attribute for .wav files isn't `audio/wav` but instead `audio/x-wav`.   
I changed the check in this pull request to detect both `audio/wav` and `audio/x-wav` as a .wav file. (the contents are the same, the OS just assigns a different MIME type to it)   

Also, I made it not just silently ignore the file and only show the error in console (who looks in the console if they don't use it on a day-to-day basis), it now instead pops up saying "Invalid file type. Please select a .wav file.". 