### PR TITLE
Lp norm

### DIFF
--- a/main.py
+++ b/main.py
@@ -861,6 +861,25 @@ def pad_and_stack_arrays(arrays):
     
     return stacked_array
 
+def L_p_norm(f, p):
+    """ Computes the L^p-norm of the provided vector, ||f||_{L^p}.
+    See https://en.wikipedia.org/wiki/Lp_space for more details.
+    In order to be able to compare norms of vectors of different length, the function will interpret the vector as a
+    function and calculate the norm as a rectangular approximation over the unit interval [0,1].
+
+    Parameters
+    ----------
+    f : array
+        A numpy array containing real values.
+    p : float
+        The power used in the L^p norm. Higher values of p puts more emphasis on the larger elements in vector.
+
+    Returns
+    -------
+    ||f||_{L^p} : float
+        A non-negative real value.
+    """
+    return np.power(np.mean(np.power(np.absolute(f), p)), 1 / p)
 
 if __name__ == '__main__':
     main()

--- a/main.py
+++ b/main.py
@@ -802,7 +802,14 @@ def plot_stat(fig, best_peaks):
     num_bins = int(1 + (3.322 * np.log(len(x_data))))
 
     mean_x = best_peaks["MeanDiff"] 
-    std_x = best_peaks["StdDiff"] 
+    std_x = best_peaks["StdDiff"]
+
+    # Calculate the Lp error of the distribution.
+    # Potential improvements:
+    #   1. Allow p as user input. Currently, 2 is used.
+    #   2. Instead of the mean of the diffs, use the users provided bpm_target (and corresponding target diff).
+    norm_p = 2
+    data_norm = L_p_norm(x_data-mean_x, norm_p)
 
     number_of_standard_devations = 5
     max_dist= max(abs(mean_x - min(x_data)),abs(mean_x + max(x_data)))
@@ -832,6 +839,11 @@ def plot_stat(fig, best_peaks):
     text_annotation2 = Label(x=0, y=fig.height-125, x_units="screen", y_units='screen', text="mean = "+f"{mean_x:.2f}"+" ms", text_font_size="16pt")
     fig.add_layout(text_annotation1)
     fig.add_layout(text_annotation2)
+
+    # Add Lp annotation
+    text_annotation3 = Label(x=0, y=fig.height - 150, x_units="screen", y_units='screen',
+                             text="L" + norm_p + " error = " + f"{data_norm:.2f}", text_font_size="16pt")
+    fig.add_layout(text_annotation3)
     
     fig.x_range.start = mean_x - (number_of_standard_devations) * std_x
     fig.x_range.end = mean_x + (number_of_standard_devations) * std_x

--- a/main.py
+++ b/main.py
@@ -842,7 +842,7 @@ def plot_stat(fig, best_peaks):
 
     # Add Lp annotation
     text_annotation3 = Label(x=0, y=fig.height - 150, x_units="screen", y_units='screen',
-                             text="L" + norm_p + " error = " + f"{data_norm:.2f}", text_font_size="16pt")
+                             text="L" + str(norm_p) + " error = " + f"{data_norm:.2f}"+" ms", text_font_size="16pt")
     fig.add_layout(text_annotation3)
     
     fig.x_range.start = mean_x - (number_of_standard_devations) * std_x


### PR DESCRIPTION
Added feature:
A function to calculate the Lp norm of a vector (interpreted as a function over the unit interval).
This currently adds a small annotation to the statistics figure, with p=2 fixed, but can be extended to:
1. Accept p from the user.
2. Compare performance with a target mean diff obtained by the target bpm. It currently uses the estimated mean diff.
3. Evaluate long-time performance from a window of beats, given by the user.